### PR TITLE
A new operator [] on DString will be available in C3 0.6.5

### DIFF
--- a/c3ws.c3
+++ b/c3ws.c3
@@ -405,13 +405,13 @@ fn Ws_Message! Ws.read_message(ws)
                     // Verifying UTF-8
                     while VERIFY: (verify_pos < payload.len()) {
                         usz size = payload.len() - verify_pos;
-                        if (catch excuse = ws::utf8_to_char32_fixed(&payload.str_view()[verify_pos], &size)) {
+                        if (catch excuse = ws::utf8_to_char32_fixed(&payload[verify_pos], &size)) {
                             case ExtraUnicodeResult.SHORT_UTF8:
                                 if (!frame.fin) {
                                     usz saved_len = payload.len();
                                     payload.extend_unfinished_utf8(verify_pos);
                                     size = payload.len() - verify_pos;
-                                    ws::utf8_to_char32_fixed(&payload.str_view()[verify_pos], &size)!;
+                                    ws::utf8_to_char32_fixed(&payload[verify_pos], &size)!;
                                     payload.chop(saved_len);
                                     break VERIFY; // Tolerating the unfinished UTF-8 sequences if the message is unfinished
                                 }


### PR DESCRIPTION
Dear Sir Tsoding,

I've done some exploratory and entertaining work on DString of C3.
You can see what's new here in the merged commit: https://github.com/c3lang/c3c/commit/a0f4976b071d2c0112cd32129d5d1b8382e844cf (Thank you Lerno!)
A new version of C3 incorporating this modification is not yet available.
So, at your convenience, you can merge this pull request when C3 0.6.5 is released.

With the expression of my gratefulness, please accept, Sir Tsoding, the assurance of my highest esteem and best regards,
Neo